### PR TITLE
chore(storagebox): downgrade `path` to `1.8.0`

### DIFF
--- a/packages/storagebox/pubspec.yaml
+++ b/packages/storagebox/pubspec.yaml
@@ -4,12 +4,12 @@ version: 0.1.0+1
 repository: https://github.com/invertase/dart-cli-utilities/tree/main/packages/storagebox
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
+  sdk: '>=2.15.0 <3.0.0'
 
 dev_dependencies:
   test: ^1.16.0
 dependencies:
   collection: ^1.15.0
   meta: ^1.7.0
-  path: ^1.8.1
+  path: ^1.8.0
   xdg_directories: ^0.2.0


### PR DESCRIPTION
`path` is incompatible with `flutter_test`, which created a conflict in `flutterfire_desktop`, wondering if we can downgrade to solve the issue.

```
Because every version of firebase_auth_dart from path depends on storagebox ^0.1.0+1 which depends on path ^1.8.1, every version of firebase_auth_dart from path requires path ^1.8.1.
And because every version of flutter_test from sdk depends on path 1.8.0, firebase_auth_dart from path is incompatible with flutter_test from sdk.
So, because firebase_auth_desktop_example depends on both flutter_test from sdk and firebase_auth_dart from path, version solving failed.
pub get failed (1; So, because firebase_auth_desktop_example depends on both flutter_test from sdk and firebase_auth_dart from path, version solving failed.)
BootstrapException: failed to install firebase_auth_desktop at /Users/mais/Documents/Invertase/flutterfire_dart/packages/firebase_auth/firebase_auth_desktop.
```