### PR TITLE
ci(*): replace `flutter format` with `dart format`

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -30,6 +30,6 @@ scripts:
   format: dart format -o write .
 
   format-check:
-    run: melos exec flutter format . --set-exit-if-changed
-    description: Run `flutter format` checks for all packages.
+    run: melos exec dart format . --set-exit-if-changed
+    description: Run `dart format` checks for all packages.
 


### PR DESCRIPTION
`flutter format` shouldn't be used anymore:

```
[!] The "format" command is deprecated and will be removed in a future version of Flutter. Please use the "dart format" sub-command instead,
which takes all of the same command-line arguments as "flutter format".
```